### PR TITLE
dataprep: general wording

### DIFF
--- a/docs/develop/prep/code/expectations.ipynb
+++ b/docs/develop/prep/code/expectations.ipynb
@@ -15,7 +15,7 @@
     "Great Expectations\n",
     "------------------\n",
     "\n",
-    "`Great expentations` es una libreria en `Python` y una utilidad de linea de comandos que provee un lenguaje declarativo para y flexible para describir nuestras expectativas sobre como los datos deben lucir. Permite validar y documentar la calidad de los datos para luego facilmente comunicar los resultados.\n",
+    "`Great expentations` es una libreria en `Python` y una utilidad de linea de comandos que provee un lenguaje declarativo y flexible para describir nuestras expectativas sobre como los datos deben lucir. Permite validar y documentar la calidad de los datos para luego facilmente comunicar los resultados.\n",
     "\n",
     "Podemos instalar `Great Expectations` en `Python` como sigue:\n",
     "\n",
@@ -81,7 +81,7 @@
     "-------\n",
     "Utilizaremos el conjunto de datos [NYC Taxi data](https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page). Cada registro en los datos corresponde a un viaje en taxi y contiene información como el lugar donde se toma el taxi y el lugar donde el pasajero se baja del mismo, el monto del pago y el número de pasajeros, entre otros.\n",
     "\n",
-    "Si bien este conjunto de datos es actualizado cada mes, en nuestro caso solu utilizaremos dos archivos CSV correspondiente a 2 meses, cada uno con una muestra de 10,000 filas del conjunto Yellow Taxi Trip Records:\n",
+    "Si bien este conjunto de datos es actualizado cada mes, en nuestro caso sólo utilizaremos dos archivos CSV correspondientes a 2 meses, cada uno con una muestra de 10,000 filas del conjunto Yellow Taxi Trip Records:\n",
     "\n",
     "- yellow_tripdata_sample_2019-01.csv: una muestra de los datos de taxis de enero de 2019\n",
     "\n",
@@ -1383,7 +1383,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Una vez que se generó el perfil de los datos, podemos constuir nuestra suite de expectativas:"
+    "Una vez que se generó el perfil de los datos, podemos construir nuestro suite de expectativas:"
    ]
   },
   {
@@ -1511,7 +1511,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Una forma más amena de explorar estas expectativas es construyendo la documentación de las mismas. Esta documentación se genera automáticamente leyendo las expectativas de los datos que se generaron. Esto es una excelente forma de comunicar a los diferentes equipos de la organización lo que pueden esperar de estos datos:"
+    "Una forma más amena de explorar estas expectativas es construyendo su documentación. Esta documentación se genera automáticamente leyendo las expectativas de los datos que se generaron. Esto es una excelente forma de comunicar a los diferentes equipos de la organización lo que pueden esperar de estos datos:"
    ]
   },
   {


### PR DESCRIPTION
Facu, hay una expresion que dice "suite de expectativas" no sugerí ningún cambio porque lo más probble es que sea una expresión que se usa y yo no conozca. Pero, podría ser "set de expectativas"
Además, lo de solo vs sólo, lo que una vez me dijeron para que me acuerde como funciona es: se usa sólo cuando se puede reemplazar por solamente. 
último, lo de la expresion "los mismos" "las mismas" tbn como regla nemotecnica se usa cuando comparamos. Para referenciar en general todes los usamos pero al parecer es un uso que se propago y que en realidad se puede reemplazar por el su adelante y listo. Obvio que es una cuestion que no hace al entendimiento, lo agregue por las dudas.